### PR TITLE
Fix language activation events and alias for couper / hcl

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,11 @@
   "keywords": [
     "couper.hcl",
     "couper",
-    "couper.io"
+    "couper.io",
+    "hcl"
   ],
   "categories": [
+    "Programming Languages",
     "Other"
   ],
   "icon": "images/couper_logo.png",
@@ -28,9 +30,14 @@
     "languages": [
       {
         "id": "couper",
+        "aliases": [
+          "Couper",
+          "couper",
+          "hcl"
+        ],
         "extensions": [
-          "hcl",
-          "couper"
+          ".hcl",
+          ".couper"
         ],
         "configuration": "./language-configuration.json"
       }
@@ -44,7 +51,9 @@
     ]
   },
   "activationEvents": [
-    "*"
+    "onLanguage:hcl",
+    "onLanguage:couper",
+    "workspaceContains:**/*.hcl"
   ],
   "devDependencies": {
     "vscode": "^1.1.37"

--- a/package.json
+++ b/package.json
@@ -31,9 +31,7 @@
       {
         "id": "couper",
         "aliases": [
-          "Couper",
-          "couper",
-          "hcl"
+          "Couper"
         ],
         "extensions": [
           ".hcl",
@@ -51,7 +49,6 @@
     ]
   },
   "activationEvents": [
-    "onLanguage:hcl",
     "onLanguage:couper",
     "workspaceContains:**/*.hcl"
   ],

--- a/src/completion.js
+++ b/src/completion.js
@@ -3,7 +3,7 @@
 const vscode = require('vscode')
 const { attributes, blocks, variables } = require('./schema')
 
-const selector = { scheme: 'file', language: 'hcl' }
+const selector = { language: 'couper' }
 
 const parentBlockRegex = /\b([\w-]+)(?:[ \t]+"[^"]+")?[ \t]*{[^{}]*$/s
 const blockRegex = /{[^{}]*}/sg


### PR DESCRIPTION
An update to activate and select this extension for **couper** language configuration.

Add cors and disable_access_control auto-completion