### PR TITLE
add github action for publishing to open-vsx

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,8 +8,13 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - run: npm i
-    - uses: lannonbr/vsce-action@2.0.0
+    - name: 'Publish to Microsoft Marketplace'
+      uses: lannonbr/vsce-action@2.0.0
       with:
         args: 'publish -p "$VSCE_TOKEN"'
       env:
         VSCE_TOKEN: ${{ secrets.VSCE_TOKEN }}
+    - name: 'Publish to Open VSX Registry'
+      uses: HaaLeo/publish-vscode-extension@v0
+      with:
+        pat: ${{ secrets.OPEN_VSX_TOKEN }}


### PR DESCRIPTION
Making our extension also available for https://open-vsx.org/

Claiming the related namespace is pending: https://github.com/EclipseFdn/open-vsx.org/issues/639