### PR TITLE
allowed-methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - `disable_private_caching` attribute for `jwt` block [#65](https://github.com/avenga/couper-vscode/pull/65)
 - `beta_scope_map` attribute for `jwt` block [#66](https://github.com/avenga/couper-vscode/pull/66)
 - `backend_request` and `backend_response` variables [#64](https://github.com/avenga/couper-vscode/pull/64)
+- `allowed_methods` attribute for `api` or `endpoint` blocks [#68](https://github.com/avenga/couper-vscode/pull/68)
 
 ### Fixed
 

--- a/src/schema.js
+++ b/src/schema.js
@@ -135,6 +135,10 @@ const attributes = {
         parents: ['cors'],
         type: 'boolean'
     },
+    allowed_methods: {
+        parents: ['api', 'endpoint'],
+        type: 'array'
+    },
     allowed_origins: {
         parents: ['cors'],
         type: 'array'

--- a/src/schema.js
+++ b/src/schema.js
@@ -137,7 +137,8 @@ const attributes = {
     },
     allowed_methods: {
         parents: ['api', 'endpoint'],
-        type: 'array'
+        type: 'array',
+        options: ['GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS']
     },
     allowed_origins: {
         parents: ['cors'],


### PR DESCRIPTION
`allowed_methods` attribute for `api` and `endpoint` blocks