### PR TITLE
Fix: always provide `backend` block completion _with_ label…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 ### Fixed
 
 - many highlighting issues [#76](https://github.com/avenga/couper-vscode/pull/76)
+- completion for labeled `backend` block [#82](https://github.com/avenga/couper-vscode/pull/82)
 
 ---
 

--- a/src/schema.js
+++ b/src/schema.js
@@ -13,8 +13,8 @@ const blocks = {
         parents: ['beta_oauth2', 'definitions', 'jwt', 'oauth2', 'oidc', 'proxy', 'request'],
         description: "Defines the connection to a local/remote backend service.",
         examples: ['backend-configuration'],
-        labelled: (parentBlockName) => {
-            return parentBlockName === "definitions"
+        labels: (parentBlockName) => {
+            return parentBlockName === "definitions" ? [DEFAULT_LABEL] : [DEFAULT_LABEL, null]
         }
     },
     basic_auth: {


### PR DESCRIPTION
… even outside `definitons` block.