### PR TITLE
Completion for reusable proxy blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - completion for `beta_token_request` block, `backend`, `backends` and `beta_token_response` variables [#100](https://github.com/avenga/couper-vscode/pull/100)
 - completion for new `grant_type`s `"password"` and `"urn:ietf:params:oauth:grant-type:jwt-bearer"` and related attributes for `oauth2` block [#105](https://github.com/avenga/couper-vscode/pull/105)
 - completion for `beta_rate_limit` [#94](https://github.com/avenga/couper-vscode/pull/94)
+- completion for reusable `proxy` blocks [#106](https://github.com/avenga/couper-vscode/pull/106)
 
 ### Fixed
 

--- a/src/schema.js
+++ b/src/schema.js
@@ -137,7 +137,9 @@ const blocks = {
 		parents: ['endpoint', 'error_handler'],
 		description: "Executes a proxy request to a backend service.",
 		examples: ['api-proxy', 'custom-requests', 'multiple-requests'],
-		labels: [null, DEFAULT_LABEL]
+		labels: (parentBlockName) => {
+			return parentBlockName === "definitions" ? [DEFAULT_LABEL] : [DEFAULT_LABEL, null]
+		}
 	},
 	request: {
 		parents: ['endpoint', 'error_handler'],
@@ -495,6 +497,10 @@ const attributes = {
 		parents: ['beta_rate_limit'],
 		options: ['wait', 'block']
 	},
+	name: {
+		parents: ['proxy'],
+		description: "Defines the proxy request name. Allowed only in the definitions block.",
+	},
 	no_proxy_from_env: {
 		parents: ['settings'],
 		type: 'boolean'
@@ -528,8 +534,8 @@ const attributes = {
 		parents: ['beta_rate_limit'],
 		type: 'number'
 	},
-	proxy: {
-		parents: ['backend']
+	proxy: { // (label reference in endpoints)
+		parents: ['backend', 'endpoint']
 	},
 	query_params: {
 		parents: ['beta_token_request', 'request'],

--- a/src/schema.js
+++ b/src/schema.js
@@ -134,7 +134,7 @@ const blocks = {
 		labelled: false
 	},
 	proxy: {
-		parents: ['endpoint', 'error_handler'],
+		parents: ['definitions', 'endpoint', 'error_handler'],
 		description: "Executes a proxy request to a backend service.",
 		examples: ['api-proxy', 'custom-requests', 'multiple-requests'],
 		labels: (parentBlockName) => {


### PR DESCRIPTION
* `proxy` block in `definitions`
* `proxy` attribute in `endpoint`