### PR TITLE
`client_secret_jwt` and `private_key_jwt`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased](https://github.com/avenga/couper/compare-vscode/v1.5.1...master)
 
+### Added
+
+- completion for OAuth2 client authentication methods `client_secret_jwt` and `private_key_jwt` [#113](https://github.com/avenga/couper-vscode/pull/113)
+
 ---
 
 ## [v1.5.1](https://github.com/avenga/couper-vscode/releases/tag/v1.5.1)

--- a/src/schema.js
+++ b/src/schema.js
@@ -110,10 +110,12 @@ const blocks = {
 		labelled: true
 	},
 	jwt_signing_profile: {
-		parents: ['definitions'],
+		parents: ['definitions', 'beta_oauth2', 'oauth2', 'oidc'],
 		description: "Configure a JSON Web Token signing profile which is referenced in the `jwt_sign()` function.",
 		examples: ['creating-jwt'],
-		labelled: true
+		labels: (parentBlockName) => {
+			return parentBlockName === "definitions" ? [DEFAULT_LABEL] : [null]
+		}
 	},
 	oauth2: {
 		parents: ['backend'],

--- a/src/schema.js
+++ b/src/schema.js
@@ -663,7 +663,7 @@ const attributes = {
 	},
 	token_endpoint_auth_method: {
 		parents: ['beta_oauth2', 'oauth2', 'oidc'],
-		options: ['client_secret_basic', 'client_secret_post']
+		options: ['client_secret_basic', 'client_secret_jwt', 'client_secret_post', 'private_key_jwt']
 	},
 	token: {
 		parents: ['beta_token_request']

--- a/test/checks.test.js
+++ b/test/checks.test.js
@@ -69,7 +69,7 @@ describe('Attribute value checks', () => {
 		["jwks_ttl", '"60min"', 'Invalid value for "jwks_ttl", duration required.'],
 		["jwks_ttl", '3600', 'Invalid value for "jwks_ttl", duration required.'],
 		["max_connections", '"1000"', 'Invalid value for "max_connections", number required.'],
-		["token_endpoint_auth_method", '"foo"', 'Invalid value for "token_endpoint_auth_method", must be one of: "client_secret_basic", "client_secret_post"'],
+		["token_endpoint_auth_method", '"foo"', 'Invalid value for "token_endpoint_auth_method", must be one of: "client_secret_basic", "client_secret_jwt", "client_secret_post", "private_key_jwt"'],
 		["allowed_methods", '"POST"', 'Invalid value for "allowed_methods", tuple required.'],
 		["allowed_origins", '42', 'Invalid value for "allowed_origins", type must be one of: "string", "tuple"'],
 		["add_request_headers", '"User-Agent: foo"', 'Invalid value for "add_request_headers", object required.'],


### PR DESCRIPTION
* new values for `token_endpoint_auth_method`: `"client_secret_jwt"` and `"private_key_jwt"`
* `jwt_signing_profile` block (without label) in `beta_oauth2`, `oauth2` and `oidc` blocks