### PR TITLE
fix: validate error_handler labels per parent block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - false-positive "Invalid label for block error_handler" diagnostics for valid labeled `error_handler` blocks (e.g. `error_handler "backend_timeout" {}`) [#142](https://github.com/coupergateway/couper-vscode/pull/142)
 - missing `error_handler` label completions per parent block context [#142](https://github.com/coupergateway/couper-vscode/pull/142)
 - outdated error type labels (added `jwt_token_inactive`, `saml2`; removed nonexistent `beta_insufficient_permissions`) [#142](https://github.com/coupergateway/couper-vscode/pull/142)
+- missing `new` keyword in boolean attribute completion causing TypeError at runtime [#142](https://github.com/coupergateway/couper-vscode/pull/142)
+- orphaned overlay entries `beta_health` and `beta_job` (renamed to `health` and `job`) [#142](https://github.com/coupergateway/couper-vscode/pull/142)
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased](https://github.com/coupergateway/couper-vscode/compare/v1.10.1...master)
 
+### Fixed
+
+- false-positive "Invalid label for block error_handler" diagnostics for valid labeled `error_handler` blocks (e.g. `error_handler "backend_timeout" {}`) [#142](https://github.com/coupergateway/couper-vscode/pull/142)
+- missing `error_handler` label completions per parent block context [#142](https://github.com/coupergateway/couper-vscode/pull/142)
+- outdated error type labels (added `jwt_token_inactive`, `saml2`; removed nonexistent `beta_insufficient_permissions`) [#142](https://github.com/coupergateway/couper-vscode/pull/142)
+
 ---
 
 ## [v1.10.1](https://github.com/coupergateway/couper-vscode/releases/tag/v1.10.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - phantom blocks `beta_health` and `beta_job` in completion, next to the real `health` and `job` [#145](https://github.com/coupergateway/couper-vscode/pull/145)
 - outdated `error_handler` error types (added `jwt_token_inactive`, `saml2`; removed nonexistent `beta_insufficient_permissions`) [#145](https://github.com/coupergateway/couper-vscode/pull/145)
+- false-positive "Invalid label for block error_handler" diagnostics for valid labeled `error_handler` blocks (e.g. `error_handler "backend_timeout" {}`) [#142](https://github.com/coupergateway/couper-vscode/pull/142)
+- missing `error_handler` label completions per parent block context [#142](https://github.com/coupergateway/couper-vscode/pull/142)
+- outdated error type labels (added `jwt_token_inactive`, `saml2`; removed nonexistent `beta_insufficient_permissions`) [#142](https://github.com/coupergateway/couper-vscode/pull/142)
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - false-positive "Invalid label for block error_handler" diagnostics for valid labeled `error_handler` blocks (e.g. `error_handler "backend_timeout" {}`) [#142](https://github.com/coupergateway/couper-vscode/pull/142)
 - missing `error_handler` label completions per parent block context [#142](https://github.com/coupergateway/couper-vscode/pull/142)
 - outdated error type labels (added `jwt_token_inactive`, `saml2`; removed nonexistent `beta_insufficient_permissions`) [#142](https://github.com/coupergateway/couper-vscode/pull/142)
+- missing `new` keyword in boolean attribute completion causing TypeError at runtime [#142](https://github.com/coupergateway/couper-vscode/pull/142)
+- orphaned overlay entries `beta_health` and `beta_job` (renamed to `health` and `job`) [#142](https://github.com/coupergateway/couper-vscode/pull/142)
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,7 @@
 - outdated `error_handler` error types (added `jwt_token_inactive`, `saml2`; removed nonexistent `beta_insufficient_permissions`) [#145](https://github.com/coupergateway/couper-vscode/pull/145)
 - false-positive "Invalid label for block error_handler" diagnostics for valid labeled `error_handler` blocks (e.g. `error_handler "backend_timeout" {}`) [#142](https://github.com/coupergateway/couper-vscode/pull/142)
 - missing `error_handler` label completions per parent block context [#142](https://github.com/coupergateway/couper-vscode/pull/142)
-- outdated error type labels (added `jwt_token_inactive`, `saml2`; removed nonexistent `beta_insufficient_permissions`) [#142](https://github.com/coupergateway/couper-vscode/pull/142)
 - missing `new` keyword in boolean attribute completion causing TypeError at runtime [#142](https://github.com/coupergateway/couper-vscode/pull/142)
-- orphaned overlay entries `beta_health` and `beta_job` (renamed to `health` and `job`) [#142](https://github.com/coupergateway/couper-vscode/pull/142)
 
 ---
 

--- a/scripts/merge-schema.js
+++ b/scripts/merge-schema.js
@@ -153,14 +153,9 @@ const functions = {
 ${toJsObject(merged.functions)}
 }
 
-const commonProperties = ['body', 'context', 'cookies', 'headers', 'json_body']
-
 const variables = {
 ${toJsObject(merged.variables)}
 }
-
-const ALL_BLOCKS = Object.keys(blocks)
-const ALL_BLOCKS_BUT_ENVIRONMENT = ALL_BLOCKS.filter(block => block !== "environment")
 
 module.exports = { attributes, blocks, functions, variables, DEFAULT_LABEL }
 `;

--- a/src/checks.js
+++ b/src/checks.js
@@ -125,6 +125,20 @@ function checkBlockLabels(name, labels, parentBlock) {
 				return CheckFailed(`Invalid character in label "${label}": ${label.charAt(index)}. Label is used as variable name, only 'a-z', 'A-Z', '0-9' and '_' are allowed.`)
 			}
 		}
+
+		// Validate error_handler labels against allowed types for the parent block
+		if (name === "error_handler" && element.labelsForParent && parentBlock) {
+			const allowedLabels = element.labelsForParent[parentBlock]
+			if (allowedLabels) {
+				// error_handler supports space-separated types like "jwt_token_expired jwt_token_missing"
+				const types = label.split(/\s+/).filter(t => t !== "")
+				for (const type of types) {
+					if (!allowedLabels.includes(type)) {
+						return CheckFailed(`Unknown error type "${type}" for error_handler in "${parentBlock}".`, vscode.DiagnosticSeverity.Warning)
+					}
+				}
+			}
+		}
 	}
 
 	return CheckOK

--- a/src/checks.js
+++ b/src/checks.js
@@ -134,7 +134,7 @@ function checkBlockLabels(name, labels, parentBlock) {
 				const types = label.split(/\s+/).filter(t => t !== "")
 				for (const type of types) {
 					if (!allowedLabels.includes(type)) {
-						return CheckFailed(`Unknown error type "${type}" for error_handler in "${parentBlock}".`, vscode.DiagnosticSeverity.Warning)
+						return CheckFailed(`Unsupported error type "${type}" for error_handler in "${parentBlock}".`, vscode.DiagnosticSeverity.Warning)
 					}
 				}
 			}

--- a/src/checks.js
+++ b/src/checks.js
@@ -126,6 +126,20 @@ function checkBlockLabels(name, labels, parentBlock) {
 				return CheckFailed(`Invalid character in label "${label}": ${label.charAt(index)}. Label is used as variable name, only 'a-z', 'A-Z', '0-9' and '_' are allowed.`)
 			}
 		}
+
+		// Validate error_handler labels against allowed types for the parent block
+		if (name === "error_handler" && element.labelsForParent && parentBlock) {
+			const allowedLabels = element.labelsForParent[parentBlock]
+			if (allowedLabels) {
+				// error_handler supports space-separated types like "jwt_token_expired jwt_token_missing"
+				const types = label.split(/\s+/).filter(t => t !== "")
+				for (const type of types) {
+					if (!allowedLabels.includes(type)) {
+						return CheckFailed(`Unknown error type "${type}" for error_handler in "${parentBlock}".`, vscode.DiagnosticSeverity.Warning)
+					}
+				}
+			}
+		}
 	}
 
 	return CheckOK

--- a/src/checks.js
+++ b/src/checks.js
@@ -135,7 +135,7 @@ function checkBlockLabels(name, labels, parentBlock) {
 				const types = label.split(/\s+/).filter(t => t !== "")
 				for (const type of types) {
 					if (!allowedLabels.includes(type)) {
-						return CheckFailed(`Unknown error type "${type}" for error_handler in "${parentBlock}".`, vscode.DiagnosticSeverity.Warning)
+						return CheckFailed(`Unsupported error type "${type}" for error_handler in "${parentBlock}".`, vscode.DiagnosticSeverity.Warning)
 					}
 				}
 			}

--- a/src/completion.js
+++ b/src/completion.js
@@ -317,7 +317,7 @@ for (const [f, details] of Object.entries(functions)) {
 
 				switch (attributes[attrName].type) {
 					case 'boolean': {
-						return [ vscode.CompletionItem(label, vscode.CompletionItemKind.Constant) ]
+						return [ new vscode.CompletionItem(label, vscode.CompletionItemKind.Constant) ]
 					}
 				}
 				return undefined

--- a/src/completion.js
+++ b/src/completion.js
@@ -55,6 +55,12 @@ function isCompletionAllowedAtContext(element, hclContext, parentBlock) {
 }
 
 function getBlockLabels(block, parentBlock) {
+	if (block.labelsForParent && parentBlock) {
+		const parentLabels = block.labelsForParent[parentBlock]
+		if (parentLabels) {
+			return [null, ...parentLabels]
+		}
+	}
 	let labels = (typeof block.labels === 'function') ? block.labels(parentBlock) : block.labels
 	if (!Array.isArray(labels) || labels.length === 0) {
 		const labelled = !!((typeof block.labelled === 'function') ? block.labelled(parentBlock) : block.labelled)

--- a/src/schema-overlay.json
+++ b/src/schema-overlay.json
@@ -25,17 +25,7 @@
       "examples": ["environment"]
     },
     "error_handler": {
-      "examples": ["error-handling-ba", "sequences"],
-      "_labelsForParent": {
-        "api": ["access_control", "backend", "backend_timeout", "backend_openapi_validation", "backend_throttle_exceeded", "backend_unhealthy", "beta_backend_token_request", "insufficient_permissions", "beta_insufficient_permissions"],
-        "basic_auth": ["access_control", "basic_auth", "basic_auth_credentials_missing"],
-        "endpoint": ["access_control", "backend", "backend_timeout", "backend_openapi_validation", "backend_throttle_exceeded", "backend_unhealthy", "beta_backend_token_request", "endpoint", "insufficient_permissions", "beta_insufficient_permissions", "sequence", "unexpected_status"],
-        "jwt": ["access_control", "jwt", "jwt_token_expired", "jwt_token_invalid", "jwt_token_missing"],
-        "saml": ["access_control", "saml"],
-        "beta_oauth2": ["access_control", "oauth2"],
-        "oidc": ["access_control", "oauth2"],
-        "rate_limiter": ["access_control", "rate_limiter"]
-      }
+      "examples": ["error-handling-ba", "sequences"]
     },
     "files": {
       "examples": ["simple-fileserving", "spa-serving"]

--- a/src/schema-overlay.json
+++ b/src/schema-overlay.json
@@ -8,11 +8,11 @@
     "backend": {
       "examples": ["backend-configuration"]
     },
-    "beta_health": {
+    "health": {
       "examples": ["health-check"],
       "docs": "/configuration/block/health"
     },
-    "beta_job": {
+    "job": {
       "docs": "/configuration/block/job"
     },
     "beta_oauth2": {

--- a/src/schema.js
+++ b/src/schema.js
@@ -1,6 +1,6 @@
 // Auto-generated from Couper Go code with manual overlay
 // Do not edit directly - modify schema-overlay.json instead
-// Generated: 2026-03-15T08:36:10.552Z
+// Generated: 2026-03-15T08:36:18.063Z
 
 
 const DEFAULT_LABEL = "…"
@@ -83,12 +83,14 @@ const blocks = {
 		examples: ["simple-fileserving","spa-serving"]
 	},
 	health: {
-
+		examples: ["health-check"],
+		docs: "/configuration/block/health"
 	},
 	job: {
 		parents: ["definitions"],
 		description: "Configure a job (zero or more).",
-		labelled: true
+		labelled: true,
+		docs: "/configuration/block/job"
 	},
 	jwt: {
 		parents: ["definitions"],
@@ -176,13 +178,6 @@ const blocks = {
 	websockets: {
 		parents: ["proxy"],
 		description: "Configures support for websockets connections (zero or one)."
-	},
-	beta_health: {
-		examples: ["health-check"],
-		docs: "/configuration/block/health"
-	},
-	beta_job: {
-		docs: "/configuration/block/job"
 	}
 }
 
@@ -1178,8 +1173,6 @@ const functions = {
 	}
 }
 
-const commonProperties = ['body', 'context', 'cookies', 'headers', 'json_body']
-
 const variables = {
 	backend: {
 		parents: ["backend"],
@@ -1226,8 +1219,5 @@ const variables = {
 		values: ["body","context","cookies","headers","json_body","form_body","host","id","method","origin","path","path_params","port","protocol","query","url"]
 	}
 }
-
-const ALL_BLOCKS = Object.keys(blocks)
-const ALL_BLOCKS_BUT_ENVIRONMENT = ALL_BLOCKS.filter(block => block !== "environment")
 
 module.exports = { attributes, blocks, functions, variables, DEFAULT_LABEL }

--- a/src/schema.js
+++ b/src/schema.js
@@ -1,6 +1,6 @@
 // Auto-generated from Couper Go code with manual overlay
 // Do not edit directly - modify schema-overlay.json instead
-// Generated: 2026-03-15T08:18:56.533Z
+// Generated: 2026-03-15T08:36:10.552Z
 
 
 const DEFAULT_LABEL = "…"
@@ -74,8 +74,7 @@ const blocks = {
 		description: "Configures an error handler (zero or more).",
 		labelOptional: true,
 		labelsForParent: {"api":["access_control","backend","backend_openapi_validation","backend_throttle_exceeded","backend_timeout","backend_unhealthy","beta_backend_token_request","insufficient_permissions"],"basic_auth":["access_control","basic_auth","basic_auth_credentials_missing"],"beta_oauth2":["access_control","oauth2"],"endpoint":["access_control","backend","backend_openapi_validation","backend_throttle_exceeded","backend_timeout","backend_unhealthy","beta_backend_token_request","endpoint","insufficient_permissions","sequence","unexpected_status"],"jwt":["access_control","jwt","jwt_token_expired","jwt_token_inactive","jwt_token_invalid","jwt_token_missing"],"oidc":["access_control","oauth2"],"rate_limiter":["access_control","beta_rate_limiter","beta_rate_limiter_key"],"saml":["access_control","saml","saml2"]},
-		examples: ["error-handling-ba","sequences"],
-		_labelsForParent: {"api":["access_control","backend","backend_timeout","backend_openapi_validation","backend_throttle_exceeded","backend_unhealthy","beta_backend_token_request","insufficient_permissions","beta_insufficient_permissions"],"basic_auth":["access_control","basic_auth","basic_auth_credentials_missing"],"endpoint":["access_control","backend","backend_timeout","backend_openapi_validation","backend_throttle_exceeded","backend_unhealthy","beta_backend_token_request","endpoint","insufficient_permissions","beta_insufficient_permissions","sequence","unexpected_status"],"jwt":["access_control","jwt","jwt_token_expired","jwt_token_invalid","jwt_token_missing"],"saml":["access_control","saml"],"beta_oauth2":["access_control","oauth2"],"oidc":["access_control","oauth2"],"rate_limiter":["access_control","rate_limiter"]}
+		examples: ["error-handling-ba","sequences"]
 	},
 	files: {
 		parents: ["server"],

--- a/src/schema.js
+++ b/src/schema.js
@@ -1214,8 +1214,6 @@ const functions = {
 	}
 }
 
-const commonProperties = ['body', 'context', 'cookies', 'headers', 'json_body']
-
 const variables = {
 	backend: {
 		parents: ["backend"],
@@ -1262,8 +1260,5 @@ const variables = {
 		values: ["body","context","cookies","headers","json_body","form_body","host","id","method","origin","path","path_params","port","protocol","query","url"]
 	}
 }
-
-const ALL_BLOCKS = Object.keys(blocks)
-const ALL_BLOCKS_BUT_ENVIRONMENT = ALL_BLOCKS.filter(block => block !== "environment")
 
 module.exports = { attributes, blocks, functions, variables, DEFAULT_LABEL }

--- a/test/checks.test.js
+++ b/test/checks.test.js
@@ -134,16 +134,16 @@ describe('error_handler label checks', () => {
 	// Valid labels per parent
 	describe('valid labels', () => {
 		test.each([
-			["api", "backend_timeout"],
-			["api", "backend"],
-			["endpoint", "sequence"],
-			["endpoint", "unexpected_status"],
-			["jwt", "jwt_token_expired"],
-			["jwt", "jwt_token_inactive"],
-			["basic_auth", "basic_auth_credentials_missing"],
-			["saml", "saml2"],
-			["rate_limiter", "beta_rate_limiter"],
-		])('error_handler "%s" in %s → ok', (parent, label) => {
+			["backend_timeout", "api"],
+			["backend", "api"],
+			["sequence", "endpoint"],
+			["unexpected_status", "endpoint"],
+			["jwt_token_expired", "jwt"],
+			["jwt_token_inactive", "jwt"],
+			["basic_auth_credentials_missing", "basic_auth"],
+			["saml2", "saml"],
+			["beta_rate_limiter", "rate_limiter"],
+		])('error_handler "%s" in %s → ok', (label, parent) => {
 			expect(checkBlockLabels("error_handler", ` "${label}" `, parent)).toStrictEqual({ok: true})
 		})
 	})
@@ -157,17 +157,32 @@ describe('error_handler label checks', () => {
 		})
 	})
 
+	// Space-separated multi-type labels
+	describe('space-separated types', () => {
+		test('all valid types → ok', () => {
+			expect(checkBlockLabels("error_handler", ' "jwt_token_expired jwt_token_missing" ', "jwt")).toStrictEqual({ok: true})
+		})
+
+		test('mixed valid and invalid types → warning on first invalid', () => {
+			expect(checkBlockLabels("error_handler", ' "jwt_token_expired backend_timeout" ', "jwt")).toStrictEqual({
+				ok: false,
+				message: 'Unsupported error type "backend_timeout" for error_handler in "jwt".',
+				severity: vscode.DiagnosticSeverity.Warning
+			})
+		})
+	})
+
 	// Invalid label for parent
 	describe('invalid labels', () => {
 		test.each([
-			["api", "jwt_token_expired"],
-			["api", "sequence"],
-			["jwt", "backend_timeout"],
-			["basic_auth", "jwt_token_missing"],
-		])('error_handler "%s" in %s → warning', (parent, label) => {
+			["jwt_token_expired", "api"],
+			["sequence", "api"],
+			["backend_timeout", "jwt"],
+			["jwt_token_missing", "basic_auth"],
+		])('error_handler "%s" in %s → warning', (label, parent) => {
 			expect(checkBlockLabels("error_handler", ` "${label}" `, parent)).toStrictEqual({
 				ok: false,
-				message: `Unknown error type "${label}" for error_handler in "${parent}".`,
+				message: `Unsupported error type "${label}" for error_handler in "${parent}".`,
 				severity: vscode.DiagnosticSeverity.Warning
 			})
 		})
@@ -178,7 +193,7 @@ describe('error_handler label checks', () => {
 		test('completely unknown error type → warning', () => {
 			expect(checkBlockLabels("error_handler", ' "nonexistent_error" ', "api")).toStrictEqual({
 				ok: false,
-				message: 'Unknown error type "nonexistent_error" for error_handler in "api".',
+				message: 'Unsupported error type "nonexistent_error" for error_handler in "api".',
 				severity: vscode.DiagnosticSeverity.Warning
 			})
 		})

--- a/test/checks.test.js
+++ b/test/checks.test.js
@@ -119,6 +119,72 @@ describe('Block label checks', () => {
 	})
 })
 
+describe('error_handler label checks', () => {
+	const checkBlockLabels = __private.checkBlockLabels
+
+	// No label (wildcard) is always valid in any parent
+	describe('no label', () => {
+		test.each([
+			"api", "endpoint", "basic_auth", "jwt",
+		])('error_handler without label in %s → ok', (parent) => {
+			expect(checkBlockLabels("error_handler", "", parent)).toStrictEqual({ok: true})
+		})
+	})
+
+	// Valid labels per parent
+	describe('valid labels', () => {
+		test.each([
+			["api", "backend_timeout"],
+			["api", "backend"],
+			["endpoint", "sequence"],
+			["endpoint", "unexpected_status"],
+			["jwt", "jwt_token_expired"],
+			["jwt", "jwt_token_inactive"],
+			["basic_auth", "basic_auth_credentials_missing"],
+			["saml", "saml2"],
+			["rate_limiter", "beta_rate_limiter"],
+		])('error_handler "%s" in %s → ok', (parent, label) => {
+			expect(checkBlockLabels("error_handler", ` "${label}" `, parent)).toStrictEqual({ok: true})
+		})
+	})
+
+	// access_control super-type is valid in any parent
+	describe('access_control super-type', () => {
+		test.each([
+			"api", "endpoint", "basic_auth", "jwt", "beta_oauth2", "oidc", "saml", "rate_limiter",
+		])('error_handler "access_control" in %s → ok', (parent) => {
+			expect(checkBlockLabels("error_handler", ' "access_control" ', parent)).toStrictEqual({ok: true})
+		})
+	})
+
+	// Invalid label for parent
+	describe('invalid labels', () => {
+		test.each([
+			["api", "jwt_token_expired"],
+			["api", "sequence"],
+			["jwt", "backend_timeout"],
+			["basic_auth", "jwt_token_missing"],
+		])('error_handler "%s" in %s → warning', (parent, label) => {
+			expect(checkBlockLabels("error_handler", ` "${label}" `, parent)).toStrictEqual({
+				ok: false,
+				message: `Unknown error type "${label}" for error_handler in "${parent}".`,
+				severity: vscode.DiagnosticSeverity.Warning
+			})
+		})
+	})
+
+	// Unknown label
+	describe('unknown labels', () => {
+		test('completely unknown error type → warning', () => {
+			expect(checkBlockLabels("error_handler", ' "nonexistent_error" ', "api")).toStrictEqual({
+				ok: false,
+				message: 'Unknown error type "nonexistent_error" for error_handler in "api".',
+				severity: vscode.DiagnosticSeverity.Warning
+			})
+		})
+	})
+})
+
 describe('Attribute value checks', () => {
 	let testcases = [
 		["websockets", "false"],

--- a/test/checks.test.js
+++ b/test/checks.test.js
@@ -142,7 +142,8 @@ describe('error_handler label checks', () => {
 			["jwt_token_inactive", "jwt"],
 			["basic_auth_credentials_missing", "basic_auth"],
 			["saml2", "saml"],
-			["beta_rate_limiter", "rate_limiter"],
+			["beta_rate_limiter", "beta_rate_limiter"],
+			["authzen_invalid_credentials", "beta_authzen"],
 		])('error_handler "%s" in %s → ok', (label, parent) => {
 			expect(checkBlockLabels("error_handler", ` "${label}" `, parent)).toStrictEqual({ok: true})
 		})
@@ -151,7 +152,7 @@ describe('error_handler label checks', () => {
 	// access_control super-type is valid in any parent
 	describe('access_control super-type', () => {
 		test.each([
-			"api", "endpoint", "basic_auth", "jwt", "beta_oauth2", "oidc", "saml", "rate_limiter",
+			"api", "endpoint", "basic_auth", "jwt", "beta_oauth2", "oidc", "saml", "beta_rate_limiter", "beta_authzen",
 		])('error_handler "access_control" in %s → ok', (parent) => {
 			expect(checkBlockLabels("error_handler", ' "access_control" ', parent)).toStrictEqual({ok: true})
 		})
@@ -179,6 +180,7 @@ describe('error_handler label checks', () => {
 			["sequence", "api"],
 			["backend_timeout", "jwt"],
 			["jwt_token_missing", "basic_auth"],
+			["jwt_token_expired", "beta_rate_limiter"],
 		])('error_handler "%s" in %s → warning', (label, parent) => {
 			expect(checkBlockLabels("error_handler", ` "${label}" `, parent)).toStrictEqual({
 				ok: false,


### PR DESCRIPTION
## Context

Couper generates `labelsForParent` for `error_handler`: the error types each parent block accepts. The extension never read it, so every labelled `error_handler` produced a false "Invalid label for block" diagnostic, and completion offered no error types at all.

This reads that field in both places.

## Changes

- `checks.js` validates an `error_handler` label against the types its parent block allows, including space-separated multi-type labels. The severity is a warning, not an error, so an extension that lags behind Couper does not reject valid configuration.
- `completion.js` offers the error types that fit the parent block.
- `completion.js` constructs `vscode.CompletionItem` with `new`. Without it the boolean attribute completion threw a `TypeError` at runtime.
- `merge-schema.js` no longer emits `commonProperties`, `ALL_BLOCKS` and `ALL_BLOCKS_BUT_ENVIRONMENT`. Nothing reads them.
- 31 tests over valid, invalid, unknown and multi-type labels across the parent blocks.

## Stack

Stacked on #145, which rebuilds `src/schema.js` from the current `generated/schema.json`. That rebuild is what puts `labelsForParent` in the file this branch reads, and it renames the parent `rate_limiter` to `beta_rate_limiter`, which the tests assert. Merge #145 first.

No successor.

## Test plan

- [x] `npm run jest` — 150 tests pass
- [x] `npm run check:schema` — no drift
- [x] `npm run build:schema` leaves `src/schema.js` unchanged
- [ ] Manual: `error_handler "backend_timeout" {}` in an `api` block — no diagnostic
- [ ] Manual: `error_handler "jwt_token_expired" {}` in an `api` block — warning
- [ ] Manual: completion suggests the error types of the parent block
