### PR TITLE
Automate the schema follow-up work

### DIFF
--- a/.github/workflows/schema-sync.yaml
+++ b/.github/workflows/schema-sync.yaml
@@ -20,6 +20,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 2
+          # The commit step below pushes, so the credential has to stay in the
+          # git config. An empty ssh-key falls back to GITHUB_TOKEN; set the
+          # secret to a write deploy key if branch protection rejects that.
+          persist-credentials: true
+          ssh-key: ${{ secrets.SCHEMA_SYNC_DEPLOY_KEY }}
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/schema-sync.yaml
+++ b/.github/workflows/schema-sync.yaml
@@ -1,0 +1,70 @@
+name: Sync schema
+
+# Couper pushes generated/schema.json here. Everything that has to follow it
+# happens in this job, so a schema change cannot reach a release half applied.
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'generated/schema.json'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - run: npm ci
+
+      - name: Reconcile the overlay and rebuild the schema
+        run: |
+          previous="$RUNNER_TEMP/previous-schema.json"
+          git show HEAD~1:generated/schema.json > "$previous" 2>/dev/null || :
+          if [ -s "$previous" ]; then
+            node scripts/schema-drift.js --fix --baseline "$previous"
+          else
+            node scripts/schema-drift.js --fix
+          fi
+          node scripts/merge-schema.js
+
+      - run: npm run jest -- --color
+
+      - name: Detect what the rebuild changed
+        id: rebuild
+        run: |
+          if git diff --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            git --no-pager diff --stat
+          fi
+
+      # The bot cannot open a pull request, so it commits its own result. The
+      # commit touches no path this workflow triggers on and cannot loop.
+      - name: Commit as the couper bot
+        if: steps.rebuild.outputs.changed == 'true' && github.actor == 'couper-svc'
+        run: |
+          git config user.name "couper-svc"
+          git config user.email "321729849+couper-svc@users.noreply.github.com"
+          git add src/schema.js src/schema-overlay.json
+          git commit -m "chore: rebuild schema after sync from couper
+
+          Reconciled by scripts/schema-drift.js for ${{ github.sha }}."
+          git push
+
+      - name: Reject a manual push that left the schema unbuilt
+        if: steps.rebuild.outputs.changed == 'true' && github.actor != 'couper-svc'
+        run: |
+          echo "::error::generated/schema.json changed but src/schema.js was not rebuilt. Run 'npm run sync:schema' and commit the result."
+          exit 1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - run: npm install
+    - run: npm ci
     - run: npm run jest -- --color
     - run: npm run check:schema
     # The merge is deterministic, so a rebuild that changes the file means the

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,8 @@
 name: Test
 
 on:
+  push:
+    branches: [master]
   pull_request:
   workflow_dispatch:
 
@@ -11,3 +13,4 @@ jobs:
     - uses: actions/checkout@v3
     - run: npm install
     - run: npm run jest -- --color
+    - run: npm run check:schema

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,3 +14,7 @@ jobs:
     - run: npm install
     - run: npm run jest -- --color
     - run: npm run check:schema
+    # The merge is deterministic, so a rebuild that changes the file means the
+    # committed one does not match the overlay it was built from.
+    - run: npm run build:schema
+    - run: git diff --exit-code -- src/schema.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased](https://github.com/coupergateway/couper-vscode/compare/v1.10.1...master)
 
+### Fixed
+
+- phantom blocks `beta_health` and `beta_job` in completion, next to the real `health` and `job` [#145](https://github.com/coupergateway/couper-vscode/pull/145)
+- outdated `error_handler` error types (added `jwt_token_inactive`, `saml2`; removed nonexistent `beta_insufficient_permissions`) [#145](https://github.com/coupergateway/couper-vscode/pull/145)
+
 ---
 
 ## [v1.10.1](https://github.com/coupergateway/couper-vscode/releases/tag/v1.10.1)

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "watch-web": "webpack --watch",
     "package-web": "webpack --mode production --devtool hidden-source-map",
     "build:schema": "node scripts/merge-schema.js",
+    "check:schema": "node scripts/schema-drift.js",
+    "sync:schema": "node scripts/schema-drift.js --fix && node scripts/merge-schema.js",
     "jest": "jest --verbose",
     "lint": "eslint src --ext js"
   },

--- a/scripts/merge-schema.js
+++ b/scripts/merge-schema.js
@@ -134,10 +134,10 @@ function toJsObject(obj, indent = '\t') {
     return lines.join(',\n');
 }
 
-// Build output
+// Build output. The result is committed, so identical inputs must produce an
+// identical file: a timestamp here would make every rebuild look like a change.
 let output = `// Auto-generated from Couper Go code with manual overlay
 // Do not edit directly - modify schema-overlay.json instead
-// Generated: ${new Date().toISOString()}
 
 ${helperFunctions}
 

--- a/scripts/schema-drift.js
+++ b/scripts/schema-drift.js
@@ -1,0 +1,234 @@
+#!/usr/bin/env node
+"use strict"
+
+/**
+ * Reconciles the hand-maintained files with the schema Couper generates.
+ *
+ * Couper owns the block and attribute names. When it renames one, the overlay
+ * entry under the old name stays behind, and the merge adds it to the output
+ * as an entry Couper does not have. This resolves what is mechanical and
+ * stops on what needs a decision, so no rename reaches the extension silently.
+ *
+ * Usage:
+ *   node scripts/schema-drift.js [--fix] [--baseline <file>]
+ *
+ *   --fix                 apply the mechanical migrations, then report the rest
+ *   --baseline <file>     an earlier generated/schema.json, to list what changed
+ */
+
+const fs = require('fs')
+const path = require('path')
+
+const root = path.join(__dirname, '..')
+const generatedPath = path.join(root, 'generated', 'schema.json')
+const overlayPath = path.join(root, 'src', 'schema-overlay.json')
+const renamesPath = path.join(__dirname, 'schema-renames.json')
+const blockRulesPath = path.join(root, 'src', 'block-rules.js')
+
+const SECTIONS = ['blocks', 'attributes', 'functions', 'variables']
+const BETA = 'beta_'
+
+function readJson(file) {
+	try {
+		return JSON.parse(fs.readFileSync(file, 'utf8'))
+	} catch (err) {
+		console.error(`Failed to read ${path.relative(root, file)}: ${err.message}`)
+		process.exit(1)
+	}
+}
+
+// Keeps arrays of primitives on one line, matching the overlay's own style.
+function formatJson(value, level = 0) {
+	const indent = '  '
+	const pad = indent.repeat(level)
+	const padInner = indent.repeat(level + 1)
+
+	if (Array.isArray(value)) {
+		if (value.every(item => item === null || typeof item !== 'object')) {
+			return JSON.stringify(value)
+		}
+		const items = value.map(item => padInner + formatJson(item, level + 1))
+		return `[\n${items.join(',\n')}\n${pad}]`
+	}
+
+	if (value !== null && typeof value === 'object') {
+		const entries = Object.entries(value)
+		if (entries.length === 0) {
+			return '{}'
+		}
+		const lines = entries.map(([key, val]) => `${padInner}${JSON.stringify(key)}: ${formatJson(val, level + 1)}`)
+		return `{\n${lines.join(',\n')}\n${pad}}`
+	}
+
+	return JSON.stringify(value)
+}
+
+// A renamed entry is found either in the rename map or by toggling the beta_
+// prefix, which is how Couper graduates a feature out of beta.
+function findNewName(section, key, generated, renames) {
+	const mapped = (renames[section] || {})[key]
+	if (mapped) {
+		return generated[section][mapped]
+			? { target: mapped, via: 'schema-renames.json' }
+			: { target: mapped, via: 'schema-renames.json', missing: true }
+	}
+
+	const toggled = key.startsWith(BETA) ? key.slice(BETA.length) : BETA + key
+	if (generated[section][toggled]) {
+		return { target: toggled, via: 'beta_ prefix' }
+	}
+
+	return null
+}
+
+function collectDeadKeys(overlay) {
+	const dead = []
+	for (const section of SECTIONS) {
+		for (const [name, entry] of Object.entries(overlay[section] || {})) {
+			if (entry === null || typeof entry !== 'object') {
+				continue
+			}
+			for (const key of Object.keys(entry)) {
+				if (key.startsWith('_')) {
+					dead.push({ section, name, key })
+				}
+			}
+		}
+	}
+	return dead
+}
+
+function reportBaseline(baseline, generated) {
+	const lines = []
+	for (const section of ['blocks', 'attributes']) {
+		const before = Object.keys(baseline[section] || {})
+		const after = Object.keys(generated[section] || {})
+		const added = after.filter(key => !before.includes(key))
+		const removed = before.filter(key => !after.includes(key))
+		if (added.length) {
+			lines.push(`  ${section} added:   ${added.join(', ')}`)
+		}
+		if (removed.length) {
+			lines.push(`  ${section} removed: ${removed.join(', ')}`)
+		}
+	}
+	return lines
+}
+
+function main() {
+	const args = process.argv.slice(2)
+	const fix = args.includes('--fix')
+	const baselineIndex = args.indexOf('--baseline')
+	const baselineFile = baselineIndex === -1 ? null : args[baselineIndex + 1]
+
+	const generated = readJson(generatedPath)
+	const overlay = readJson(overlayPath)
+	const renames = fs.existsSync(renamesPath) ? readJson(renamesPath) : {}
+
+	const migrated = []
+	const unresolved = []
+
+	for (const section of SECTIONS) {
+		const entries = overlay[section]
+		if (!entries) {
+			continue
+		}
+
+		for (const key of Object.keys(entries)) {
+			if (generated[section] && generated[section][key]) {
+				continue
+			}
+
+			const rename = findNewName(section, key, generated, renames)
+			if (!rename || rename.missing) {
+				unresolved.push({ section, key, rename })
+				continue
+			}
+
+			migrated.push({ section, key, ...rename })
+			if (fix) {
+				entries[rename.target] = { ...(entries[rename.target] || {}), ...entries[key] }
+				delete entries[key]
+			}
+		}
+	}
+
+	const dead = collectDeadKeys(overlay)
+	if (fix) {
+		for (const { section, name, key } of dead) {
+			delete overlay[section][name][key]
+		}
+	}
+
+	// The label rules name blocks, so they drift with a rename just as the
+	// overlay does, and nothing else would catch it.
+	delete require.cache[require.resolve(blockRulesPath)]
+	const blockRules = require(blockRulesPath)
+	const unknownRuleBlocks = []
+	for (const [rule, names] of Object.entries(blockRules)) {
+		for (const name of names) {
+			if (!generated.blocks[name]) {
+				unknownRuleBlocks.push({ rule, name })
+			}
+		}
+	}
+
+	if (fix && (migrated.length || dead.length)) {
+		fs.writeFileSync(overlayPath, formatJson(overlay) + '\n', 'utf8')
+	}
+
+	// Report
+
+	if (baselineFile) {
+		const lines = reportBaseline(readJson(baselineFile), generated)
+		if (lines.length) {
+			console.log('Couper schema changed:')
+			console.log(lines.join('\n'))
+			console.log('')
+		}
+	}
+
+	for (const { section, key, target, via } of migrated) {
+		const verb = fix ? 'migrated' : 'needs migration'
+		console.log(`overlay ${section}: "${key}" -> "${target}" (${verb}, matched via ${via})`)
+	}
+
+	for (const { section, name, key } of dead) {
+		const verb = fix ? 'removed' : 'is dead'
+		console.log(`overlay ${section}.${name}: "${key}" ${verb} — a leading underscore is not a schema key, the merge ships it verbatim`)
+	}
+
+	if (migrated.length || dead.length) {
+		console.log('')
+	}
+
+	let failed = false
+
+	for (const { section, key, rename } of unresolved) {
+		failed = true
+		if (rename && rename.missing) {
+			console.error(`error: overlay ${section} "${key}" maps to "${rename.target}" in schema-renames.json, but Couper has no such ${section.slice(0, -1)}.`)
+		} else {
+			console.error(`error: overlay ${section} "${key}" is not in the generated schema and no rename matches it.`)
+			console.error(`       Couper either renamed or removed it. Add the new name to scripts/schema-renames.json under "${section}", or drop the overlay entry.`)
+		}
+	}
+
+	for (const { rule, name } of unknownRuleBlocks) {
+		failed = true
+		console.error(`error: src/block-rules.js ${rule} lists "${name}", which is not a block in the generated schema.`)
+	}
+
+	if (failed) {
+		process.exit(1)
+	}
+
+	if (!migrated.length && !dead.length) {
+		console.log('No drift: the overlay and the label rules match the generated schema.')
+	} else if (!fix) {
+		console.error('error: drift found. Run "npm run sync:schema" to apply it.')
+		process.exit(1)
+	}
+}
+
+main()

--- a/scripts/schema-drift.js
+++ b/scripts/schema-drift.js
@@ -66,15 +66,17 @@ function formatJson(value, level = 0) {
 // A renamed entry is found either in the rename map or by toggling the beta_
 // prefix, which is how Couper graduates a feature out of beta.
 function findNewName(section, key, generated, renames) {
+	const candidates = generated[section] || {}
+
 	const mapped = (renames[section] || {})[key]
 	if (mapped) {
-		return generated[section][mapped]
+		return candidates[mapped]
 			? { target: mapped, via: 'schema-renames.json' }
 			: { target: mapped, via: 'schema-renames.json', missing: true }
 	}
 
 	const toggled = key.startsWith(BETA) ? key.slice(BETA.length) : BETA + key
-	if (generated[section][toggled]) {
+	if (candidates[toggled]) {
 		return { target: toggled, via: 'beta_ prefix' }
 	}
 

--- a/scripts/schema-drift.js
+++ b/scripts/schema-drift.js
@@ -147,9 +147,16 @@ function main() {
 				continue
 			}
 
+			// Merging two entries would have to pick a winner per key and would
+			// drop the other silently. Which one is current is a judgement.
+			if (entries[rename.target]) {
+				unresolved.push({ section, key, collision: rename.target })
+				continue
+			}
+
 			migrated.push({ section, key, ...rename })
 			if (fix) {
-				entries[rename.target] = { ...(entries[rename.target] || {}), ...entries[key] }
+				entries[rename.target] = entries[key]
 				delete entries[key]
 			}
 		}
@@ -206,13 +213,20 @@ function main() {
 
 	let failed = false
 
-	for (const { section, key, rename } of unresolved) {
+	const overlayFile = path.relative(root, overlayPath)
+	const renamesFile = path.relative(root, renamesPath)
+
+	for (const { section, key, rename, collision } of unresolved) {
 		failed = true
-		if (rename && rename.missing) {
-			console.error(`error: overlay ${section} "${key}" maps to "${rename.target}" in schema-renames.json, but Couper has no such ${section.slice(0, -1)}.`)
+		if (collision) {
+			console.error(`error: ${overlayFile} ${section} has both "${key}" and "${collision}", and Couper only has "${collision}".`)
+			console.error(`       Move what you still need into "${collision}" and delete "${key}".`)
+		} else if (rename && rename.missing) {
+			console.error(`error: ${renamesFile} maps ${section} "${key}" to "${rename.target}", but Couper has no such ${section.slice(0, -1)}.`)
+			console.error(`       Correct the mapping, or delete "${key}" from ${overlayFile}.`)
 		} else {
-			console.error(`error: overlay ${section} "${key}" is not in the generated schema and no rename matches it.`)
-			console.error(`       Couper either renamed or removed it. Add the new name to scripts/schema-renames.json under "${section}", or drop the overlay entry.`)
+			console.error(`error: ${overlayFile} ${section} "${key}" is not in the generated schema and no rename matches it.`)
+			console.error(`       Couper either renamed or removed it. Add the new name to ${renamesFile} under "${section}", or delete "${key}" from ${overlayFile}.`)
 		}
 	}
 

--- a/scripts/schema-renames.json
+++ b/scripts/schema-renames.json
@@ -1,0 +1,9 @@
+{
+  "$comment": "Renames that schema-drift.js cannot derive. A beta_ prefix that Couper adds or drops is matched automatically and does not belong here. Keys are the old name, values the new one.",
+  "blocks": {
+    "beta_external_authz": "beta_authzen"
+  },
+  "attributes": {},
+  "functions": {},
+  "variables": {}
+}

--- a/src/block-rules.js
+++ b/src/block-rules.js
@@ -1,0 +1,13 @@
+"use strict"
+
+// Label rules that Couper's generated schema does not express. They name
+// blocks, so schema-drift.js validates them against the generated schema.
+
+// Blocks that reject an empty label.
+const LABEL_MUST_NOT_BE_EMPTY = ["backend", "environment", "basic_auth", "jwt", "oidc", "saml", "beta_oauth2"]
+
+// Blocks whose label is reachable as a variable (e.g. backends.my_label), so
+// the label has to be a valid identifier.
+const LABEL_IS_VARIABLE_NAME = ["backend", "request", "proxy", "environment"]
+
+module.exports = { LABEL_MUST_NOT_BE_EMPTY, LABEL_IS_VARIABLE_NAME }

--- a/src/checks.js
+++ b/src/checks.js
@@ -3,6 +3,7 @@
 const vscode = require('vscode')
 const common = require('./common')
 const schema = require('./schema')
+const { LABEL_MUST_NOT_BE_EMPTY, LABEL_IS_VARIABLE_NAME } = require('./block-rules')
 
 const REGEXES = {
 	block: /^\s*([\w_-]+)\s*(("[^"]*"\s*)*)\s*{/,
@@ -111,7 +112,7 @@ function checkBlockLabels(name, labels, parentBlock) {
 	const labelArray = [...labels.matchAll(REGEXES.labels)].map(match => match[1])
 	if (labelArray.length > 0) {
 		const label = labelArray[0] // Check only first label for now
-		if (["backend", "environment", "basic_auth", "jwt", "oidc", "saml", "beta_oauth2"].includes(name)) {
+		if (LABEL_MUST_NOT_BE_EMPTY.includes(name)) {
 			if (label === "") {
 				return CheckFailed("Label must not be empty.")
 			}
@@ -119,7 +120,7 @@ function checkBlockLabels(name, labels, parentBlock) {
 
 		// These blocks are accessible as variables (e.g. backends.my_label),
 		// so labels must be valid identifiers — no hyphens or special chars.
-		if (["backend", "request", "proxy", "environment"].includes(name)) {
+		if (LABEL_IS_VARIABLE_NAME.includes(name)) {
 			const index = label.search(REGEXES.labelsyntax)
 			if (index !== -1) {
 				return CheckFailed(`Invalid character in label "${label}": ${label.charAt(index)}. Label is used as variable name, only 'a-z', 'A-Z', '0-9' and '_' are allowed.`)

--- a/src/schema-overlay.json
+++ b/src/schema-overlay.json
@@ -8,13 +8,6 @@
     "backend": {
       "examples": ["backend-configuration"]
     },
-    "beta_health": {
-      "examples": ["health-check"],
-      "docs": "/configuration/block/health"
-    },
-    "beta_job": {
-      "docs": "/configuration/block/job"
-    },
     "beta_oauth2": {
       "docs": "/configuration/block/oauth2"
     },
@@ -25,23 +18,13 @@
       "examples": ["environment"]
     },
     "error_handler": {
-      "examples": ["error-handling-ba", "sequences"],
-      "_labelsForParent": {
-        "api": ["access_control", "backend", "backend_timeout", "backend_openapi_validation", "backend_throttle_exceeded", "backend_unhealthy", "beta_backend_token_request", "insufficient_permissions", "beta_insufficient_permissions"],
-        "basic_auth": ["access_control", "basic_auth", "basic_auth_credentials_missing"],
-        "endpoint": ["access_control", "backend", "backend_timeout", "backend_openapi_validation", "backend_throttle_exceeded", "backend_unhealthy", "beta_backend_token_request", "endpoint", "insufficient_permissions", "beta_insufficient_permissions", "sequence", "unexpected_status"],
-        "jwt": ["access_control", "jwt", "jwt_token_expired", "jwt_token_invalid", "jwt_token_missing"],
-        "saml": ["access_control", "saml"],
-        "beta_oauth2": ["access_control", "oauth2"],
-        "oidc": ["access_control", "oauth2"],
-        "rate_limiter": ["access_control", "rate_limiter"]
-      }
+      "examples": ["error-handling-ba","sequences"]
     },
     "files": {
-      "examples": ["simple-fileserving", "spa-serving"]
+      "examples": ["simple-fileserving","spa-serving"]
     },
     "jwt": {
-      "examples": ["jwt-access-control", "creating-jwt"]
+      "examples": ["jwt-access-control","creating-jwt"]
     },
     "jwt_signing_profile": {
       "examples": ["creating-jwt"]
@@ -57,10 +40,10 @@
       "examples": ["backend-validation"]
     },
     "proxy": {
-      "examples": ["api-proxy", "custom-requests", "multiple-requests"]
+      "examples": ["api-proxy","custom-requests","multiple-requests"]
     },
     "request": {
-      "examples": ["custom-requests", "multiple-requests"]
+      "examples": ["custom-requests","multiple-requests"]
     },
     "response": {
       "examples": ["static-responses"]
@@ -70,6 +53,13 @@
     },
     "spa": {
       "examples": ["spa-serving"]
+    },
+    "health": {
+      "examples": ["health-check"],
+      "docs": "/configuration/block/health"
+    },
+    "job": {
+      "docs": "/configuration/block/job"
     }
   },
   "attributes": {
@@ -80,10 +70,10 @@
       "examples": ["query"]
     },
     "allowed_methods": {
-      "options": ["GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "*"]
+      "options": ["GET","HEAD","POST","PUT","PATCH","DELETE","OPTIONS","*"]
     },
     "allowed_origins": {
-      "type": ["string", "tuple"]
+      "type": ["string","tuple"]
     },
     "array_attributes": {
       "examples": ["saml"]
@@ -98,19 +88,19 @@
       "examples": ["jwt-access-control"]
     },
     "client_id": {
-      "examples": ["oauth2-client-credentials", "oidc"]
+      "examples": ["oauth2-client-credentials","oidc"]
     },
     "client_secret": {
-      "examples": ["oauth2-client-credentials", "oidc"]
+      "examples": ["oauth2-client-credentials","oidc"]
     },
     "configuration_url": {
       "examples": ["oidc"]
     },
     "custom_log_fields": {
-      "examples": ["custom-logging", "sequences"]
+      "examples": ["custom-logging","sequences"]
     },
     "document_root": {
-      "examples": ["simple-fileserving", "spa-serving"]
+      "examples": ["simple-fileserving","spa-serving"]
     },
     "environment_variables": {
       "examples": ["env-var"]
@@ -122,7 +112,7 @@
       "examples": ["sequences"]
     },
     "grant_type": {
-      "options": ["authorization_code", "client_credentials", "password", "urn:ietf:params:oauth:grant-type:jwt-bearer"]
+      "options": ["authorization_code","client_credentials","password","urn:ietf:params:oauth:grant-type:jwt-bearer"]
     },
     "header": {
       "examples": ["jwt-access-control"]
@@ -146,22 +136,22 @@
       "examples": ["jwt-access-control"]
     },
     "log_format": {
-      "options": ["common", "json"]
+      "options": ["common","json"]
     },
     "log_level": {
-      "options": ["info", "panic", "fatal", "error", "warn", "debug", "trace"]
+      "options": ["info","panic","fatal","error","warn","debug","trace"]
     },
     "mode": {
-      "options": ["wait", "block"]
+      "options": ["wait","block"]
     },
     "paths": {
       "examples": ["spa-serving"]
     },
     "period_window": {
-      "options": ["sliding", "fixed"]
+      "options": ["sliding","fixed"]
     },
     "permissions_claim": {
-      "examples": ["permissions", "permissions-map", "permissions-rbac"]
+      "examples": ["permissions","permissions-map","permissions-rbac"]
     },
     "permissions_map": {
       "examples": ["permissions-map"]
@@ -176,13 +166,13 @@
       "examples": ["query"]
     },
     "request_id_format": {
-      "options": ["common", "uuid4"]
+      "options": ["common","uuid4"]
     },
     "required_claims": {
       "examples": ["jwt-access-control"]
     },
     "required_permission": {
-      "examples": ["permissions", "permissions-map", "permissions-rbac"]
+      "examples": ["permissions","permissions-map","permissions-rbac"]
     },
     "roles_claim": {
       "examples": ["permissions-rbac"]
@@ -194,7 +184,7 @@
       "examples": ["permissions-rbac"]
     },
     "secure_cookies": {
-      "options": ["strip", ""]
+      "options": ["strip",""]
     },
     "set_query_params": {
       "examples": ["query"]
@@ -203,7 +193,7 @@
       "examples": ["sending-jwt-upstream"]
     },
     "signature_algorithm": {
-      "options": ["ES256", "ES384", "ES512", "HS256", "HS384", "HS512", "RS256", "RS384", "RS512"],
+      "options": ["ES256","ES384","ES512","HS256","HS384","HS512","RS256","RS384","RS512"],
       "examples": ["jwt-access-control"]
     },
     "sp_acs_url": {
@@ -216,13 +206,13 @@
       "examples": ["static-responses"]
     },
     "token_endpoint_auth_method": {
-      "options": ["client_secret_basic", "client_secret_jwt", "client_secret_post", "private_key_jwt"]
+      "options": ["client_secret_basic","client_secret_jwt","client_secret_post","private_key_jwt"]
     },
     "token_value": {
       "examples": ["jwt-access-control"]
     },
     "verifier_method": {
-      "options": ["ccm_s256", "nonce", "state"]
+      "options": ["ccm_s256","nonce","state"]
     }
   },
   "functions": {
@@ -238,7 +228,7 @@
   },
   "variables": {
     "env": {
-      "examples": ["env-var", "docker-compose#environment-variables"]
+      "examples": ["env-var","docker-compose#environment-variables"]
     }
   }
 }

--- a/src/schema.js
+++ b/src/schema.js
@@ -1,6 +1,5 @@
 // Auto-generated from Couper Go code with manual overlay
 // Do not edit directly - modify schema-overlay.json instead
-// Generated: 2026-08-27T14:27:08.297Z
 
 
 const DEFAULT_LABEL = "…"
@@ -84,8 +83,7 @@ const blocks = {
 		description: "Configures an error handler (zero or more).",
 		labelOptional: true,
 		labelsForParent: {"api":["access_control","backend","backend_openapi_validation","backend_throttle_exceeded","backend_timeout","backend_unhealthy","beta_backend_token_request","insufficient_permissions"],"basic_auth":["access_control","basic_auth","basic_auth_credentials_missing"],"beta_authzen":["access_control","authzen","authzen_insufficient_permissions","authzen_invalid_credentials"],"beta_oauth2":["access_control","oauth2"],"beta_rate_limiter":["access_control","beta_rate_limiter","beta_rate_limiter_key"],"endpoint":["access_control","backend","backend_openapi_validation","backend_throttle_exceeded","backend_timeout","backend_unhealthy","beta_backend_token_request","endpoint","insufficient_permissions","sequence","unexpected_status"],"jwt":["access_control","jwt","jwt_token_expired","jwt_token_inactive","jwt_token_invalid","jwt_token_missing"],"oidc":["access_control","oauth2"],"saml":["access_control","saml","saml2"]},
-		examples: ["error-handling-ba","sequences"],
-		_labelsForParent: {"api":["access_control","backend","backend_timeout","backend_openapi_validation","backend_throttle_exceeded","backend_unhealthy","beta_backend_token_request","insufficient_permissions","beta_insufficient_permissions"],"basic_auth":["access_control","basic_auth","basic_auth_credentials_missing"],"endpoint":["access_control","backend","backend_timeout","backend_openapi_validation","backend_throttle_exceeded","backend_unhealthy","beta_backend_token_request","endpoint","insufficient_permissions","beta_insufficient_permissions","sequence","unexpected_status"],"jwt":["access_control","jwt","jwt_token_expired","jwt_token_invalid","jwt_token_missing"],"saml":["access_control","saml"],"beta_oauth2":["access_control","oauth2"],"oidc":["access_control","oauth2"],"rate_limiter":["access_control","rate_limiter"]}
+		examples: ["error-handling-ba","sequences"]
 	},
 	files: {
 		parents: ["server"],
@@ -94,12 +92,14 @@ const blocks = {
 		examples: ["simple-fileserving","spa-serving"]
 	},
 	health: {
-
+		examples: ["health-check"],
+		docs: "/configuration/block/health"
 	},
 	job: {
 		parents: ["definitions"],
 		description: "Configure a job (zero or more).",
-		labelled: true
+		labelled: true,
+		docs: "/configuration/block/job"
 	},
 	jwt: {
 		parents: ["definitions"],
@@ -184,13 +184,6 @@ const blocks = {
 	websockets: {
 		parents: ["proxy"],
 		description: "Configures support for websockets connections (zero or one)."
-	},
-	beta_health: {
-		examples: ["health-check"],
-		docs: "/configuration/block/health"
-	},
-	beta_job: {
-		docs: "/configuration/block/job"
 	}
 }
 


### PR DESCRIPTION
## Context

Couper cross-pushes `generated/schema.json` to this repository. Everything that has to follow that file was manual, and the manual steps were skipped, so the shipped schema drifted from Couper.

What was wrong on `master`:

- The overlay keys `beta_health` and `beta_job` no longer exist in the generated schema. The merge does not reject an unknown key, it adds it, so `src/schema.js` offered `beta_health` **and** `health`, `beta_job` **and** `job` as separate blocks.
- `error_handler._labelsForParent` was disabled with a leading underscore, but the merge copies keys verbatim, so it shipped, naming the removed `rate_limiter` block and missing `beta_authzen`.
- Nothing rebuilt `src/schema.js` when the overlay or the merge script changed. Couper built it, so a change here only reached the output at Couper's next schema change.

## Change

`scripts/schema-drift.js` reconciles the hand-maintained files with the generated schema:

- migrates an overlay key when Couper adds or drops a `beta_` prefix,
- takes any other rename from `scripts/schema-renames.json`,
- **fails** on an overlay key it cannot resolve, naming the file to edit,
- removes underscore-disabled keys, which are not a schema feature,
- validates the label rules, now in `src/block-rules.js` instead of inline in `checks.js`,
- reports what Couper added and removed against a baseline, so a new block is not missed.

`npm run sync:schema` reconciles and rebuilds. `npm run check:schema` reports without writing and now runs on every pull request.

The merge output lost its timestamp: the file is committed, so identical inputs have to produce an identical file.

## CI

`schema-sync.yaml` runs on push to `master` for `generated/schema.json`: reconcile, rebuild, test, then commit the result when the pusher is `couper-svc`. A manual push that skipped the rebuild fails instead. The commit touches only `src/`, which the trigger does not watch, so it cannot loop.

`test.yaml` now also runs on push to `master`. A direct push never ran the tests.

## What CI now guards on a pull request

- `npm run check:schema` — the overlay and the label rules match the generated schema.
- a rebuild leaves `src/schema.js` unchanged — nobody edited the overlay without rebuilding. The merge is deterministic, so this is a reliable check.

## Verification

- `npm run check:schema` on `master` reports all three defects and exits 1; after this branch it reports no drift.
- Replaying the pending Couper rename (`health` -> `beta_health`, `token_request` -> `beta_token_request`) through the scripts migrates the overlay unattended and keeps the enrichment: `beta_health` ends up with the generated parents and description plus the overlay examples and docs.
- 119 tests pass.

`npm run lint` fails with `Invalid ecmaVersion` on all 12 `src` files including untouched ones. Pre-existing eslint config problem, not run by CI, left alone.

## Merge order

Merge this **before** coupergateway/couper#1004. That pull request renames two blocks; with this in place the rename is applied here automatically.


## Stack

No predecessor. #142 is stacked on top: it reads the `labelsForParent` field that the rebuild in this branch puts into `src/schema.js`.
